### PR TITLE
Adding `GetCondition` method to Managed resource types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ vendor/
 .cache
 .work
 _output
+
+# ignore IDE files
+.vscode/

--- a/cmd/angryjet/main.go
+++ b/cmd/angryjet/main.go
@@ -95,6 +95,7 @@ func GenerateManaged(filename, header string, p *packages.Package) error {
 
 	methods := method.Set{
 		"SetConditions":                       method.NewSetConditions(receiver, RuntimeImport),
+		"GetCondition":                        method.NewGetCondition(receiver, RuntimeImport),
 		"SetBindingPhase":                     method.NewSetBindingPhase(receiver, RuntimeImport),
 		"GetBindingPhase":                     method.NewGetBindingPhase(receiver, RuntimeImport),
 		"SetClaimReference":                   method.NewSetClaimReference(receiver, CoreImport),
@@ -128,6 +129,7 @@ func GenerateClaim(filename, header string, p *packages.Package) error {
 
 	methods := method.Set{
 		"SetConditions":                       method.NewSetConditions(receiver, RuntimeImport),
+		"GetCondition":                        method.NewGetCondition(receiver, RuntimeImport),
 		"SetBindingPhase":                     method.NewSetBindingPhase(receiver, RuntimeImport),
 		"GetBindingPhase":                     method.NewGetBindingPhase(receiver, RuntimeImport),
 		"SetResourceReference":                method.NewSetResourceReference(receiver, CoreImport),

--- a/internal/method/method.go
+++ b/internal/method/method.go
@@ -88,6 +88,17 @@ func NewSetConditions(receiver, runtime string) New {
 	}
 }
 
+// NewGetCondition returns a NewMethod that writes a GetCondition method for
+// the supplied Object to the supplied file.
+func NewGetCondition(receiver, runtime string) New {
+	return func(f *jen.File, o types.Object) {
+		f.Commentf("GetCondition of this %s.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("GetCondition").Params(jen.Id("ct").Qual(runtime, "ConditionType")).Qual(runtime, "Condition").Block(
+			jen.Return(jen.Id(receiver).Dot(fields.NameStatus).Dot("GetCondition").Call(jen.Id("ct"))),
+		)
+	}
+}
+
 // NewSetBindingPhase returns a NewMethod that writes a SetBindingPhase method
 // for the supplied Object to the supplied file.
 func NewSetBindingPhase(receiver, runtime string) New {

--- a/internal/method/method_test.go
+++ b/internal/method/method_test.go
@@ -54,6 +54,23 @@ func (t *Type) SetConditions(c ...runtime.Condition) {
 	}
 }
 
+func TestNewGetCondition(t *testing.T) {
+	want := `package pkg
+
+import runtime "example.org/runtime"
+
+// GetCondition of this Type.
+func (t *Type) GetCondition(ct runtime.ConditionType) runtime.Condition {
+	return t.Status.GetCondition(ct)
+}
+`
+	f := jen.NewFile("pkg")
+	NewGetCondition("t", "example.org/runtime")(f, MockObject{Named: "Type"})
+	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
+		t.Errorf("NewGetCondition(): -want, +got\n%s", diff)
+	}
+}
+
 func TestNewSetBindingPhase(t *testing.T) {
 	want := `package pkg
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Adding the `GetCondition` method signature introduced in 
https://github.com/crossplaneio/crossplane-runtime/pull/46/commits/f33b90e5d2ac37b8d06fa5b608eeecba03659112

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
